### PR TITLE
Update runtime to 25.08

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/io.github.retux_game.retux.appdata.xml
+++ b/io.github.retux_game.retux.appdata.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
   <id>io.github.retux_game.retux</id>
   <name>ReTux</name>
   <summary>Action platformer starring the Linux mascot, Tux</summary>
-  <developer_name/>
+  <developer id="io.github.retux-game">
+    <name>ReTux</name>
+  </developer>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <description>
-    <p>Tux is just getting ready to go fishing when all of a sudden, he receives a message. The message states that his home, Icy Island, has been taken over by the Snow King, and a new Fish Tax will be imposed. Tux is furious! How dare the Snow King take away his fish?! Help Tux overthrow the Snow King and stop him from taking Tux's fish away!</p>
-    <p>ReTux is a libre open source action platformer loosely inspired by the Mario games, utilizing the art assets from the SuperTux project. The name "ReTux" is a play on the words "redux" and "Tux".</p>
+    <p>Tux is just getting ready to go fishing when all of a sudden, he receives a message.
+      The message states that his home, Icy Island, has been taken over by the Snow King,
+      and a new Fish Tax will be imposed. Tux is furious! How dare the Snow King take away his fish?!
+      Help Tux overthrow the Snow King and stop him from taking Tux's fish away!</p>
+    <p>ReTux is a libre open source action platformer loosely inspired by the Mario games,
+      utilizing the art assets from the SuperTux project. The name "ReTux" is a play on the words "redux" and "Tux".</p>
   </description>
   <screenshots>
     <screenshot type="default">
@@ -44,13 +50,16 @@
   </screenshots>
   <releases>
     <release version="1.6.2" date="2023-02-05"/>
-    <release version="1.6.1" date="2021-10-11" type="stable"><description>
+    <release version="1.6.1" date="2021-10-11" type="stable">
+      <description>
         <p>Fixes game controller issues, updated Spanish and Esperanto translations, added level name to level HUD.</p>
       </description>
     </release>
   </releases>
   <url type="homepage">https://retux-game.github.io</url>
   <url type="bugtracker">https://github.com/retux-game/retux/issues</url>
+  <url type="vcs-browser">https://github.com/retux-game/retux</url>
+  <launchable type="desktop-id">io.github.retux_game.retux.desktop</launchable>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">mild</content_attribute>
   </content_rating>

--- a/io.github.retux_game.retux.yaml
+++ b/io.github.retux_game.retux.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.retux_game.retux
 runtime: org.freedesktop.Platform
-runtime-version: 22.08
+runtime-version: 25.08
 sdk: org.freedesktop.Sdk
 command: retux
 finish-args:
@@ -10,14 +10,18 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
 
-modules:
-  - name: portmidi
-    buildsystem: cmake-ninja
-    sources:
-      - type: git
-        url: https://github.com/PortMidi/portmidi.git
-        tag: v2.0.3
+cleanup:
+  - /include
+  - /lib/python3.*/*/pygame/docs
+  - /lib/python3.*/*/pygame/examples
+  - /lib/python3.*/*/pygame/tests
+  - /lib/python3.*/*/uniseg/docs
+cleanup-commands:
+  - python3 -m compileall --invalidation-mode=unchecked-hash /app
 
+modules:
+  - shared-modules/SDL2/SDL2_ttf.json
+  - shared-modules/SDL2/SDL2_image.json
   - python3-pygame.json
   - pypi-dependencies.json
 
@@ -30,7 +34,6 @@ modules:
       - install -Dm 755 retux.py ${FLATPAK_DEST}/share/retux/retux.py
       - install -m 644 get_errors.py globalize.py localize.py ${FLATPAK_DEST}/share/retux
       - cp -a data ${FLATPAK_DEST}/share/retux
-      - install -Dm 644 data/images/misc/icon.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
       - install -Dm 644 data/images/misc/icon.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dm 644 ${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       - install -Dm 644 ${FLATPAK_ID}.appdata.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml

--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -7,13 +7,13 @@
             "name": "python3-uniseg",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"uniseg>=0.7\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"uniseg\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/dd/3c/ed9ea7ad980ffd5af7d96f7293f80f0ec385e677ec2243fb40e4b95799c5/uniseg-0.7.1.post2-py2.py3-none-any.whl",
-                    "sha256": "1d386521f74735556899dfc83401558fe8a7a27c03b2b7acbd7ae5976eac58e7"
+                    "url": "https://files.pythonhosted.org/packages/80/6c/9eb6d93ad8b9ac96cba13e6d2f419c316d8fdb91013e12dd478a99501699/uniseg-0.10.1-py3-none-any.whl",
+                    "sha256": "74fe3f7b4ee46bbd703a70ea1e5cd28e04f63eee5af9a10388d93316c554e358"
                 }
             ]
         },
@@ -21,13 +21,23 @@
             "name": "python3-sge",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"sge>=2.0,<3.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"sge\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/37/24/52704ed3e60a54da704b6cf95fa4ec99367744296a59323820ba50446a50/sge-2.0.post0.tar.gz",
-                    "sha256": "794f1cd20abf19c5cab55fc99e5223895233ac3011671f4158b8ba4f3f2ead68"
+                    "url": "https://files.pythonhosted.org/packages/49/cc/08bba60f00541f62aaa252ce0cfbd60aebd04616c0b9574f755b583e45ae/pygame-2.6.1.tar.gz",
+                    "sha256": "56fb02ead529cee00d415c3e007f75e0780c655909aaa8e8bf616ee09c9feb1f"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b6/4e/693535e888e1eb040a0265e35dbcfff466af8dc928a83cb554e407847d8c/sge-2.0.2.tar.gz",
+                    "sha256": "1719ae32e4ac57b491cc10c211489177b4e76ecc2a3220c5eec6572dd9d5e4ae"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/80/6c/9eb6d93ad8b9ac96cba13e6d2f419c316d8fdb91013e12dd478a99501699/uniseg-0.10.1-py3-none-any.whl",
+                    "sha256": "74fe3f7b4ee46bbd703a70ea1e5cd28e04f63eee5af9a10388d93316c554e358"
                 }
             ]
         },
@@ -35,7 +45,7 @@
             "name": "python3-xsge_gui",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_gui>=1.2\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_gui\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -49,7 +59,7 @@
             "name": "python3-xsge_lighting",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_lighting>=1.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_lighting\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -63,7 +73,7 @@
             "name": "python3-xsge_path",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_path>=1.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_path\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -77,7 +87,7 @@
             "name": "python3-xsge_physics",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_physics>=0.12\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_physics\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -91,7 +101,7 @@
             "name": "python3-xsge_tiled",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_tiled>=1.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xsge_tiled\" --no-build-isolation"
             ],
             "sources": [
                 {

--- a/python3-pygame.json
+++ b/python3-pygame.json
@@ -1,120 +1,31 @@
 {
-    "name": "python3-requirements",
+    "name": "python3-pygame",
     "buildsystem": "simple",
-    "build-commands": [],
-    "modules": [
-        {
-            "name": "python3-babel",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"babel\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/60/2e/dec1cc18c51b8df33c7c4d0a321b084cf38e1733b98f9d15018880fb4970/pytz-2022.1-py2.py3-none-any.whl",
-                    "sha256": "e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/2e/57/a4177e24f8ed700c037e1eca7620097fdfbb1c9b358601e40169adf6d364/Babel-2.10.3-py3-none-any.whl",
-                    "sha256": "ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"
-                }
-            ]
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pygame\" --no-build-isolation"
+    ],
+    "build-options": {
+        "env": {
+            "PYGAME_EXTRA_BASE": "/app"
         },
-        {
-            "name": "python3-cbor",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"cbor\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/9b/99/01c6a987c920500189eb74a291bd3a388e6c7cf85736bb6b066d9833315e/cbor-1.0.0.tar.gz",
-                    "sha256": "13225a262ddf5615cbd9fd55a76a0d53069d18b07d2e9f19c39e6acb8609bbb6"
-                }
-            ]
-        },
-        {
-            "name": "python3-neteria",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"neteria\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/62/1e/a94a8d635fa3ce4cfc7f506003548d0a2447ae76fd5ca53932970fe3053f/pyasn1-0.4.8-py2.py3-none-any.whl",
-                    "sha256": "39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl",
-                    "sha256": "90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/fc/5a/ee9a9e71db8d0f986c25049ea0f158959423720d0713bdf983937ba890a2/neteria-1.0.2.tar.gz",
-                    "sha256": "67fb82606aae0cb114d4db0a289fd0a84f31265e6d813fa2d0761b05508ff4ab"
-                }
-            ]
-        },
-        {
-            "name": "python3-pillow",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/8c/92/2975b464d9926dc667020ed1abfa6276e68c3571dcb77e43347e15ee9eed/Pillow-9.2.0.tar.gz",
-                    "sha256": "75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04"
-                }
-            ]
-        },
-        {
-            "name": "python3-pygame",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pygame==2.1.2\" --no-build-isolation"
-            ],
-            "build-options": {
+        "arch": {
+            "aarch64": {
                 "env": {
-                    "PORTMIDI_INC_PORTTIME": "1",
-                    "PYGAME_EXTRA_BASE": "/app"
-                },
-                "arch": {
-                    "aarch64": {
-                        "env": {
-                            "ORIGLIBDIRS": "/lib:/lib64:/lib/aarch64-linux-gnu"
-                        }
-                    },
-                    "arm": {
-                        "env": {
-                            "ORIGLIBDIRS": "/lib:/lib/arm-linux-gnueabihf"
-                        }
-                    },
-                    "i386": {
-                        "env": {
-                            "ORIGLIBDIRS": "/lib:/lib/i386-linux-gnu"
-                        }
-                    },
-                    "x86_64": {
-                        "env": {
-                            "ORIGLIBDIRS": "/lib:/lib64:/lib/x86_64-linux-gnu"
-                        }
-                    }
+                    "ORIGLIBDIRS": "/lib:/lib64:/lib/aarch64-linux-gnu"
                 }
             },
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/9a/50/67767e5586a45e7e7b02e6f0e07853f8fcb81b54c66db6278f1a1344491f/pygame-2.1.2.tar.gz",
-                    "sha256": "d6d0eca28f886f0477cd0721ac688189155a587f2bb8eae740e52ca56c3ad23c"
+            "x86_64": {
+                "env": {
+                    "ORIGLIBDIRS": "/lib:/lib64:/lib/x86_64-linux-gnu"
                 }
-            ]
+            }
+        }
+    },
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/49/cc/08bba60f00541f62aaa252ce0cfbd60aebd04616c0b9574f755b583e45ae/pygame-2.6.1.tar.gz",
+            "sha256": "56fb02ead529cee00d415c3e007f75e0780c655909aaa8e8bf616ee09c9feb1f"
         }
     ]
 }


### PR DESCRIPTION
- Update the runtime version to 25.08
- Update pygame2 to 2.6.1
- Update pygame2 build options
- Drop portmidi module
- Add required SDL2 modules from the shared-modules
- Update cleanup commands to reduce the Flatpak size
- Compile pyc files to improve performance